### PR TITLE
feat: add rss news ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,17 @@ python -m mmw.prices --since 2022-01-01
 - **FBX** — Freightos Baltic Index. Официальная страница: https://fbx.freightos.com/
 
 Парсеры для получения текущих значений доступны, однако использовать их следует только если это не нарушает условия использования сайтов и правила robots.txt. В остальных случаях данные лучше загружать вручную через CSV.
+
+## Новости (RSS)
+Проект может получать новости из открытых RSS-лент отраслевых изданий.
+Примеры источников:
+
+- [Hellenic Shipping News](https://www.hellenicshippingnews.com/feed/)
+- [Maritime Executive](https://www.maritime-executive.com/rss)
+- [gCaptain](https://gcaptain.com/feed/)
+
+Новости можно загрузить и сохранить в базу данных командой:
+
+```bash
+python -m mmw.news
+```

--- a/src/mmw/__init__.py
+++ b/src/mmw/__init__.py
@@ -1,4 +1,4 @@
 """Maritime Market Watch package."""
 
-__all__ = ["config", "db", "utils", "prices"]
+__all__ = ["config", "db", "utils", "prices", "news"]
 __version__ = "0.1.0"

--- a/src/mmw/config.py
+++ b/src/mmw/config.py
@@ -28,8 +28,10 @@ INDEX_CODES = [
 ]
 
 RSS_FEEDS = [
-    "https://example.com/feed1",
-    "https://example.com/feed2",
+    "https://www.hellenicshippingnews.com/feed/",
+    "https://www.maritime-executive.com/rss",
+    "https://gcaptain.com/feed/",
+    # TODO: add more sources
 ]
 
 DATA_DIR = Path("data")

--- a/src/mmw/db.py
+++ b/src/mmw/db.py
@@ -75,6 +75,7 @@ class News(Base):
     __tablename__ = "news"
 
     id = Column(Integer, primary_key=True)
+    url = Column(String, unique=True, nullable=False)
     title = Column(String, nullable=False)
     summary = Column(Text)
     published_at = Column(DateTime)

--- a/src/mmw/news.py
+++ b/src/mmw/news.py
@@ -1,0 +1,96 @@
+"""Fetch and store news from RSS feeds."""
+
+from __future__ import annotations
+
+from typing import List, Dict
+
+import feedparser
+import pandas as pd
+from sqlalchemy import select
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.orm import sessionmaker
+
+from .config import RSS_FEEDS
+from .db import News, engine
+
+
+def fetch_rss(feed_url: str) -> List[Dict]:
+    """Fetch an RSS/Atom feed and return list of items."""
+
+    parsed = feedparser.parse(feed_url)
+    source = parsed.feed.get("title", feed_url)
+    items: List[Dict] = []
+    for entry in parsed.entries:
+        items.append(
+            {
+                "source": source,
+                "url": entry.get("link"),
+                "title": entry.get("title", ""),
+                "summary": entry.get("summary", ""),
+                "published": entry.get("published"),
+            }
+        )
+    return items
+
+
+def normalize_news(items: List[Dict]) -> pd.DataFrame:
+    """Normalize parsed feed items into a tidy DataFrame."""
+
+    if not items:
+        return pd.DataFrame(columns=["ts", "source", "url", "title", "summary"])
+    df = pd.DataFrame(items)
+    df["ts"] = pd.to_datetime(df["published"], errors="coerce")
+    df = df[["ts", "source", "url", "title", "summary"]]
+    return df
+
+
+def upsert_news(df: pd.DataFrame) -> int:
+    """Upsert news rows into the database by unique URL."""
+
+    if df.empty:
+        return 0
+    urls = df["url"].tolist()
+    Session = sessionmaker(bind=engine, future=True)
+    with Session.begin() as session:
+        existing = set(
+            session.scalars(select(News.url).where(News.url.in_(urls))).all()
+        )
+        for row in df.itertuples(index=False):
+            stmt = sqlite_insert(News).values(
+                url=row.url,
+                title=row.title,
+                summary=row.summary,
+                source=row.source,
+                published_at=row.ts.to_pydatetime() if pd.notnull(row.ts) else None,
+            )
+            stmt = stmt.on_conflict_do_update(
+                index_elements=[News.__table__.c.url],
+                set_={
+                    "title": row.title,
+                    "summary": row.summary,
+                    "source": row.source,
+                    "published_at": row.ts.to_pydatetime()
+                    if pd.notnull(row.ts)
+                    else None,
+                },
+            )
+            session.execute(stmt)
+    return len(set(urls) - existing)
+
+
+def refresh_news() -> None:
+    """Fetch, normalize and upsert news from all configured feeds."""
+
+    total_new = 0
+    for feed in RSS_FEEDS:
+        items = fetch_rss(feed)
+        df = normalize_news(items)
+        new_rows = upsert_news(df)
+        print(f"{feed}: {new_rows} new articles")
+        total_new += new_rows
+    print(f"Total new articles: {total_new}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    refresh_news()
+


### PR DESCRIPTION
## Summary
- add RSS feed fetching and database upsert helpers
- expand config with sample maritime news sources
- document RSS news usage and sources

## Testing
- `python -m pytest`
- `PYTHONPATH=src python -m mmw.news`

------
https://chatgpt.com/codex/tasks/task_e_68adbfb390e483339305d5124e9f652a