### PR TITLE
Call NLP and linker in refresh-all

### DIFF
--- a/src/mmw/cli.py
+++ b/src/mmw/cli.py
@@ -7,7 +7,9 @@ from pathlib import Path
 import click
 
 from .indices import refresh_indices
+from .linker import link_news
 from .news import refresh_news
+from .nlp import enrich_news
 from .prices import refresh_watchlist_prices
 from .report import build_site
 
@@ -24,6 +26,8 @@ def refresh_all() -> None:
     refresh_watchlist_prices()
     refresh_indices()
     refresh_news()
+    enrich_news()
+    link_news()
     click.echo("Data refreshed")
 
 


### PR DESCRIPTION
## Summary
- Import NLP enrichment and news linking utilities into CLI
- Ensure `mmw refresh-all` enriches and links news after fetching

## Testing
- `pytest -q`
- `PYTHONPATH=src python -m mmw.cli refresh-all` *(fails: no such table: news)*

------
https://chatgpt.com/codex/tasks/task_e_68aeaf9864f08333be9c63f967fa3f39