### PR TITLE
feat: allow custom RSS feeds via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ python -m mmw.prices --since 2022-01-01
 - [Maritime Executive](https://www.maritime-executive.com/rss)
 - [gCaptain](https://gcaptain.com/feed/)
 
+Дополнительные ленты можно указать через переменную окружения `MMW_EXTRA_FEEDS` (список URL через запятую).
+
 Новости можно загрузить и сохранить в базу данных командой:
 
 ```bash

--- a/src/mmw/config.py
+++ b/src/mmw/config.py
@@ -34,6 +34,12 @@ RSS_FEEDS = [
     # TODO: add more sources
 ]
 
+import os
+
+extra = os.getenv("MMW_EXTRA_FEEDS")
+if extra:
+    RSS_FEEDS.extend([u.strip() for u in extra.split(",") if u.strip()])
+
 DATA_DIR = Path("data")
 DB_PATH = DATA_DIR / "mmw.sqlite"
 DOCS_DIR = Path("docs")


### PR DESCRIPTION
## Summary
- add support for extra RSS feeds via the `MMW_EXTRA_FEEDS` environment variable
- document `MMW_EXTRA_FEEDS` usage in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aeb44dfb1c83339a03ac694055fdc6