### PR TITLE
Add news normalization tests and enable pytest CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   tests:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: src
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -18,11 +20,13 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install flake8 mypy
+          pip install flake8 mypy pytest
       - name: Run linters
         run: |
           flake8 src
           mypy src
+      - name: Run tests
+        run: pytest
       - name: Smoke test
         run: python -m mmw.prices --since 2022-01-01
 

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -1,0 +1,25 @@
+import pandas as pd
+
+from mmw.news import normalize_news
+
+
+def test_normalize_news_empty():
+    df = normalize_news([])
+    assert df.empty
+    assert list(df.columns) == ["ts", "source", "url", "title", "summary"]
+
+
+def test_normalize_news_parses_fields():
+    item = {
+        "title": "Some title",
+        "summary": "Short summary",
+        "published": "2024-01-02T03:04:05Z",
+        "source": "Example Feed",
+        "url": "https://example.com/article",
+    }
+    df = normalize_news([item])
+    assert df.loc[0, "title"] == item["title"]
+    assert df.loc[0, "summary"] == item["summary"]
+    assert df.loc[0, "source"] == item["source"]
+    assert df.loc[0, "url"] == item["url"]
+    assert df.loc[0, "ts"] == pd.Timestamp("2024-01-02T03:04:05Z")


### PR DESCRIPTION
## Summary
- add unit tests for `normalize_news` covering empty input and field parsing
- run pytest in CI with proper PYTHONPATH and dependencies

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeb4e7fca48333a6e03e5b00b66902