### PR TITLE
Add analytics commands to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ mmw build-site    # собрать статический сайт в docs/
 mmw open-site     # открыть docs/index.html в браузере
 ```
 
+Команда `mmw analyze` позволяет выполнить несколько простых аналитических запросов:
+
+```bash
+mmw analyze daily-returns ZIM SBLK  # посчитать дневные доходности
+mmw analyze news-intensity          # агрегировать интенсивность новостей
+```
+
 Для простого дашборда можно запустить Streamlit:
 
 ```bash


### PR DESCRIPTION
## Summary
- expose analytics helpers via new `mmw analyze` command with subcommands for daily returns and news intensity
- document how to run analytics from the command line

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=67)*
- `PYTHONPATH=src python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeeb13fb7c833385a45596c29002e1