### PR TITLE
Add CLI command to import indices from CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 
 ```bash
 mmw refresh-all   # загрузить цены, индексы и новости, обогатить и связать их
+mmw import-indices          # импортировать индексы из data/indices_manual.csv
 mmw build-site    # собрать статический сайт в docs/
 mmw open-site     # открыть docs/index.html в браузере
 ```

--- a/src/mmw/cli.py
+++ b/src/mmw/cli.py
@@ -9,7 +9,7 @@ import click
 from .analytics import compute_daily_returns, news_intensity
 from .config import WATCHLIST_TICKERS
 from .db import engine
-from .indices import refresh_indices
+from .indices import refresh_indices, import_indices_from_csv
 from .linker import link_news
 from .news import refresh_news
 from .nlp import enrich_news
@@ -32,6 +32,20 @@ def refresh_all() -> None:
     enrich_news()
     link_news()
     click.echo("Data refreshed")
+
+
+@cli.command("import-indices")
+@click.argument(
+    "path",
+    type=click.Path(path_type=Path),
+    required=False,
+    default=Path("data/indices_manual.csv"),
+)
+def import_indices_cmd(path: Path) -> None:
+    """Import indices from a CSV file into the database."""
+
+    import_indices_from_csv(path)
+    click.echo(f"Imported indices from {path}")
 
 
 @cli.command("build-site")


### PR DESCRIPTION
## Summary
- add `import-indices` CLI command to load index data from a CSV file
- document new command usage in README

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeeca253b48333bcdde787d7a625cb