### PR TITLE
Deduplicate RSS news items before upsert

### DIFF
--- a/src/mmw/news.py
+++ b/src/mmw/news.py
@@ -95,6 +95,7 @@ def refresh_news() -> None:
             logger.info("%s: no articles fetched", feed)
             continue
         df = normalize_news(items)
+        df.drop_duplicates(subset="url", inplace=True)
         new_rows = upsert_news(df)
         logger.info("%s: %s new articles", feed, new_rows)
         total_new += new_rows

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
-from mmw.news import normalize_news
+import mmw.news as news
+from mmw.news import normalize_news, refresh_news
 
 
 def test_normalize_news_empty():
@@ -23,3 +24,38 @@ def test_normalize_news_parses_fields():
     assert df.loc[0, "source"] == item["source"]
     assert df.loc[0, "url"] == item["url"]
     assert df.loc[0, "ts"] == pd.Timestamp("2024-01-02T03:04:05Z")
+
+
+def test_refresh_news_drops_duplicates(monkeypatch):
+    items = [
+        {
+            "title": "Title 1",
+            "summary": "Summary",
+            "published": "2024-01-01T00:00:00Z",
+            "source": "Feed",
+            "url": "https://example.com/a",
+        },
+        {
+            "title": "Title 2",
+            "summary": "Summary 2",
+            "published": "2024-01-01T01:00:00Z",
+            "source": "Feed",
+            "url": "https://example.com/a",
+        },
+    ]
+
+    monkeypatch.setattr(news, "RSS_FEEDS", ["dummy"])
+    monkeypatch.setattr(news, "fetch_rss", lambda feed: items)
+
+    captured = {}
+
+    def fake_upsert(df):
+        captured["df"] = df.copy()
+        return len(df)
+
+    monkeypatch.setattr(news, "upsert_news", fake_upsert)
+
+    refresh_news()
+
+    assert len(captured["df"]) == 1
+    assert captured["df"].iloc[0]["url"] == "https://example.com/a"


### PR DESCRIPTION
## Summary
- Drop duplicate URLs in `refresh_news` prior to database upsert
- Add regression test ensuring duplicate RSS items are collapsed

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeef385d9c83339a0affbaa0f642ca